### PR TITLE
ADD GISCE-TI, S.L.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@
 * Empresas con uso interno de Python
 * Empresas que buscan programadores en Python
  
+
+
+#### [GISCE-TI, S.L.](http://gisce.net)
+
+* Pl. de Mela Mutermilch, 2 1 1. 17001 Girona - 972 21 73 84 - gisce@gisce.net
+* [GitHub](http://github.com/gisce)
+* [Twitter](http://twitter.com/gisce)
+* [Localización](https://www.openstreetmap.org/#map=18/41.98333/2.81378)
+* Creamos soluciones para empresas del sector eléctrico: Comercializadoras y distribudoras. ERP y GIS. Todo en software libre.
+* *python-friendliness*: :snake: :snake: :snake:


### PR DESCRIPTION
#### [GISCE-TI, S.L.](http://gisce.net)
- Pl. de Mela Mutermilch, 2 1 1. 17001 Girona - 972 21 73 84 - gisce@gisce.net
- [GitHub](http://github.com/gisce)
- [Twitter](http://twitter.com/gisce)
- [Localización](https://www.openstreetmap.org/#map=18/41.98333/2.81378)
- Creamos soluciones para empresas del sector eléctrico: Comercializadoras y distribudoras. ERP y GIS. Todo en software libre.
- _python-friendliness_: :snake: :snake: :snake:
